### PR TITLE
added quotes for column names

### DIFF
--- a/cassandradump.py
+++ b/cassandradump.py
@@ -86,7 +86,7 @@ def table_to_cqlfile(session, keyspace, tablename, flt, tableval, filep):
                 return 'INSERT INTO "%(keyspace)s"."%(tablename)s" (%(columns)s) VALUES (%(values)s)' % dict(
                         keyspace = keyspace_utf8,
                         tablename = tablename_utf8,
-                        columns = ', '.join(c for c in columns),
+                        columns = ', '.join('"{}"'.format(c) for c in columns),
                         values = ', '.join(values[c] for c in columns),
                 )
         return row_encoder


### PR DESCRIPTION
I added this fix, added quotes on each column name.

Reason:

IF somebody dump table using this script and table contains column with uppercased letter, for example accountId

Import could not work correctly, so I need to add quotes on each column name
