### PR TITLE
fix 'NULL' values in insert statement

### DIFF
--- a/cassandradump.py
+++ b/cassandradump.py
@@ -86,8 +86,8 @@ def table_to_cqlfile(session, keyspace, tablename, flt, tableval, filep):
                 return 'INSERT INTO "%(keyspace)s"."%(tablename)s" (%(columns)s) VALUES (%(values)s)' % dict(
                         keyspace = keyspace_utf8,
                         tablename = tablename_utf8,
-                        columns = ', '.join(c for c in columns),
-                        values = ', '.join(values[c] for c in columns),
+                        columns = ', '.join(c for c in columns if values[c]!="NULL"),
+                        values = ', '.join(values[c] for c in columns if values[c]!="NULL"),
                 )
         return row_encoder
 


### PR DESCRIPTION
Reason:
Cassandra 2.x doesn't support NULL as value 
