### PR TITLE
Adding number of rows to be returned

### DIFF
--- a/cassandradump.py
+++ b/cassandradump.py
@@ -218,8 +218,8 @@ def export_data(session):
     if args.limit is not None:
         limit = args.limit
     else:
-        limit = 1000 ##for the moment I limit it to 1000 elements by force, just in case
-        #limit = 0 
+        #limit = 1000 ##for the moment I limit it to 1000 elements by force, just in case
+        limit = 0 
 
     if args.keyspace is not None:
         keyspaces = args.keyspace

--- a/cassandradump.py
+++ b/cassandradump.py
@@ -34,12 +34,15 @@ def log_quiet(msg):
         sys.stdout.flush()
 
 
-def table_to_cqlfile(session, keyspace, tablename, flt, tableval, filep):
+def table_to_cqlfile(session, keyspace, tablename, flt, tableval, filep, limit=0):
     if flt is None:
         query = 'SELECT * FROM "' + keyspace + '"."' + tablename + '"'
     else:
         query = 'SELECT * FROM ' + flt
 
+    if limit > 0: 
+        query = query + " LIMIT "+ str(limit)
+        
     rows = session.execute(query)
 
     cnt = 0
@@ -212,6 +215,12 @@ def export_data(session):
             if keyspace not in ('system', 'system_traces'):
                 keyspaces.append(keyspace)
 
+    if args.limit is not None:
+        limit = args.limit
+    else:
+        #limit = 1000 ##for the moment I limit it to 1000 elements by force, just in case
+        limit = 0 
+
     if args.keyspace is not None:
         keyspaces = args.keyspace
 
@@ -338,6 +347,8 @@ def main():
     parser.add_argument('--quiet', help='quiet progress logging', action='store_true')
     parser.add_argument('--sync', help='import data in synchronous mode (default asynchronous)', action='store_true')
     parser.add_argument('--username', help='set username for auth (only if protocol-version is set)')
+    parser.add_argument('--limit', help='set number of rows return limit')
+    
     args = parser.parse_args()
 
     if args.import_file is None and args.export_file is None:

--- a/cassandradump.py
+++ b/cassandradump.py
@@ -218,8 +218,8 @@ def export_data(session):
     if args.limit is not None:
         limit = args.limit
     else:
-        #limit = 1000 ##for the moment I limit it to 1000 elements by force, just in case
-        limit = 0 
+        limit = 1000 ##for the moment I limit it to 1000 elements by force, just in case
+        #limit = 0 
 
     if args.keyspace is not None:
         keyspaces = args.keyspace
@@ -237,7 +237,7 @@ def export_data(session):
                 if tableval.is_cql_compatible:
                     if not args.no_insert:
                         log_quiet('Exporting data for column family ' + keyname + '.' + tablename + '\n')
-                        table_to_cqlfile(session, keyname, tablename, None, tableval, f)
+                        table_to_cqlfile(session, keyname, tablename, None, tableval, f, limit)
 
     if args.cf is not None:
         for cf in args.cf:
@@ -259,7 +259,7 @@ def export_data(session):
 
                 if not args.no_insert:
                     log_quiet('Exporting data for column family ' + keyname + '.' + tablename + '\n')
-                    table_to_cqlfile(session, keyname, tablename, None, tableval, f)
+                    table_to_cqlfile(session, keyname, tablename, None, tableval, f, limit)
 
     if args.filter is not None:
         for flt in args.filter:
@@ -283,7 +283,7 @@ def export_data(session):
 
             if not args.no_insert:
                 log_quiet('Exporting data for filter "' + stripped + '"\n')
-                table_to_cqlfile(session, keyname, tablename, stripped, tableval, f)
+                table_to_cqlfile(session, keyname, tablename, stripped, tableval, f, limit)
 
     f.close()
 

--- a/cassandradump.py
+++ b/cassandradump.py
@@ -216,7 +216,7 @@ def export_data(session):
                 keyspaces.append(keyspace)
 
     if args.limit is not None:
-        limit = args.limit
+        limit = int(args.limit)
     else:
         #limit = 1000 ##for the moment I limit it to 1000 elements by force, just in case
         limit = 0 
@@ -299,7 +299,7 @@ def setup_cluster():
     if args.port is None:
         port = 9042
     else:
-        port = args.port
+        port = int(args.port)
 
     cluster = None
 


### PR DESCRIPTION
Filter was too generic for adding the limit, adding LIMIT XXXX is easier to handle if for testing purposes what I need is only to get enough data from the table with the LIMIT command

Also there was an issue when the port number was passed by commandline, it was not converted to INT and this produced an exception in the cassandra driver. Fixed too

